### PR TITLE
Separate movement and edit 

### DIFF
--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -1,5 +1,5 @@
-import {useInput} from 'ink';
-import { useState } from "react";
+import { useInput } from 'ink';
+import { useEffect, useState } from "react";
 import { AppState, SetStateFn } from '../utils';
 import { BufferCommands } from './use-buffer';
 
@@ -28,6 +28,11 @@ export const useEdit = ({
   enabled
 }: EditParams) => {
   const [isMSN, setIsMSN] = useState(true);
+
+  useEffect(() => {
+    setIsMSN(true);
+  }, [cursor]);
+
   useInput((input, key) => {
     if (isHexChar(input)) {
       const value = parseInt(input, 16);
@@ -41,11 +46,6 @@ export const useEdit = ({
       return;
     }
 
-    if (key.leftArrow || key.rightArrow || key.upArrow || key.downArrow) {
-      setIsMSN(true);
-      return;
-    }
-
     if (input === '?') {
       return setAppState(AppState.Help);
     }
@@ -56,7 +56,6 @@ export const useEdit = ({
 
     if (key.delete || key.backspace) {
       bufferCommands.delete();
-      setIsMSN(true);
       return;
     }
 

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -31,7 +31,7 @@ export const useEdit = ({
 
   useEffect(() => {
     setIsMSN(true);
-  }, [cursor]);
+  }, [cursor, buffer]);
 
   useInput((input, key) => {
     if (isHexChar(input)) {
@@ -62,12 +62,10 @@ export const useEdit = ({
     switch (input) {
       case CommandChar.InsertByteAtCursor: {
         bufferCommands.insertAtCursor(new Uint8Array([0]));
-        setIsMSN(true);
         return;
       }
       case CommandChar.InsertByteAfterCursor: {
         bufferCommands.insertAfterCursor(new Uint8Array([0]));
-        setIsMSN(true);
         return;
       }
     }


### PR DESCRIPTION
### Changelog
* Handle IsMSN flag reset on `cursor` change instead of the verbose listener on the movement keys

### Notes
Since we want to reset the `IsMSN` flag as an *effect of the movement* it's more appropriate to look at the change of the `cursor` position instead of looking at the movement keys.