### PR TITLE
use setBuffer instead of mutating buffer

### DIFF
--- a/src/hooks/use-buffer.ts
+++ b/src/hooks/use-buffer.ts
@@ -9,6 +9,7 @@ export type CursorCommands = {
 };
 
 export type BufferCommands = {
+  updateAtCursor: (byte: number) => void;
   insertAtCursor: (bytes: Uint8Array) => void;
   insertAfterCursor: (bytes: Uint8Array) => void;
   delete: () => void;
@@ -71,6 +72,11 @@ export const useBuffer = () => {
     },
   };
 
+  const updateAtCursor = (byte: number) => {
+    buffer[cursor] = byte;
+    setBuffer(buffer);
+  }
+
   const insertAtCursor = (bytes: Uint8Array) => {
     const newSize = buffer.byteLength + bytes.byteLength;
     const newBuffer = new Uint8Array(newSize);
@@ -113,6 +119,7 @@ export const useBuffer = () => {
   };
 
   const bufferCommands: BufferCommands = {
+    updateAtCursor,
     insertAtCursor,
     insertAfterCursor,
     delete: deleteByte
@@ -120,7 +127,6 @@ export const useBuffer = () => {
 
   return {
     buffer,
-    setBuffer,
     cursor,
     setCursor,
     cursorCommands,

--- a/src/hooks/use-buffer.ts
+++ b/src/hooks/use-buffer.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { BYTES_PER_LINE, HEXVIEW_H } from "../utils";
 
 export type CursorCommands = {
@@ -19,7 +19,20 @@ const cursorIsVisible = (cursor: number, offset: number) => (
 );
 
 export const useBuffer = () => {
-  const [buffer, setBuffer] = useState(new Uint8Array(0));
+  // We'll use a ref instead of a state, because we don't want to create a new Uint8Array with
+  // every edit. And then we'll use a state to trigger the re-render whenever we mutate the buffer.
+  const bufferRef = useRef<Uint8Array>();
+  const [_, forceRender] = useState({});
+  if (!bufferRef.current) {
+    bufferRef.current = new Uint8Array(0);
+  }
+  // Just make the `useRef` workaround transparent in the rest of the codebase.
+  const buffer = bufferRef.current;
+  const setBuffer = (newBuffer: Uint8Array) => {
+    bufferRef.current = newBuffer;
+    forceRender({});
+  };
+
   const [cursor, setCursor] = useState(0);
   const [offset, setOffset] = useState(0);
 

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -45,7 +45,7 @@ export const useEdit = ({
         newBuffer[cursor] = (newBuffer[cursor] & 0xf0) | value;
         moveCursorRight();
       }
-			setBuffer(newBuffer);
+      setBuffer(newBuffer);
       setIsMSN(!isMSN);
       return;
     }
@@ -60,19 +60,19 @@ export const useEdit = ({
 
     if (key.delete || key.backspace) {
       bufferCommands.delete();
-			setIsMSN(true);
+      setIsMSN(true);
       return;
     }
 
     switch (input) {
       case CommandChar.InsertByteAtCursor: {
         bufferCommands.insertAtCursor(new Uint8Array([0]));
-				setIsMSN(true);
+        setIsMSN(true);
         return;
       }
       case CommandChar.InsertByteAfterCursor: {
         bufferCommands.insertAfterCursor(new Uint8Array([0]));
-				setIsMSN(true);
+        setIsMSN(true);
         return;
       }
     }

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -16,7 +16,7 @@ type EditParams = {
   buffer: Uint8Array;
   bufferCommands: BufferCommands;
   moveCursorRight: () => void;
-	setBuffer: SetStateFn<Uint8Array>,
+  setBuffer: SetStateFn<Uint8Array>,
   setAppState: SetStateFn<AppState>;
   enabled: boolean;
 }
@@ -25,7 +25,7 @@ export const useEdit = ({
   moveCursorRight,
   bufferCommands,
   buffer,
-	setBuffer,
+  setBuffer,
   setAppState,
   enabled
 }: EditParams) => {

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -38,7 +38,7 @@ export const useEdit = ({
   useInput((input, key) => {
     if (isHexChar(input)) {
       const value = parseInt(input, 16);
-			const newBuffer = buffer.slice();
+      const newBuffer = buffer.slice();
       if (isMSN) {
         newBuffer[cursor] = (value << 4) | (newBuffer[cursor] & 0x0f);
       } else {

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -37,8 +37,8 @@ export const useEdit = ({
     if (isHexChar(input)) {
       const value = parseInt(input, 16);
       if (isMSN) {
-         const newByte = (value << 4) | (buffer[cursor] & 0x0f);
-         bufferCommands.updateAtCursor(newByte);
+        const newByte = (value << 4) | (buffer[cursor] & 0x0f);
+        bufferCommands.updateAtCursor(newByte);
       } else {
         const newByte = (buffer[cursor] & 0xf0) | value;
         bufferCommands.updateAtCursor(newByte);

--- a/src/hooks/use-edit.ts
+++ b/src/hooks/use-edit.ts
@@ -14,9 +14,9 @@ enum CommandChar {
 type EditParams = {
   cursor: number;
   buffer: Uint8Array;
-  setBuffer: SetStateFn<Uint8Array>;
   bufferCommands: BufferCommands;
   moveCursorRight: () => void;
+	setBuffer: SetStateFn<Uint8Array>,
   setAppState: SetStateFn<AppState>;
   enabled: boolean;
 }
@@ -25,7 +25,7 @@ export const useEdit = ({
   moveCursorRight,
   bufferCommands,
   buffer,
-  setBuffer,
+	setBuffer,
   setAppState,
   enabled
 }: EditParams) => {
@@ -36,49 +36,49 @@ export const useEdit = ({
   }, [cursor]);
 
   useInput((input, key) => {
-      if (isHexChar(input)) {
-        const value = parseInt(input, 16);
-        const newBuffer = buffer.slice();
-        if (isMSN) {
-          newBuffer[cursor] = (value << 4) | (newBuffer[cursor] & 0x0f);
-        } else {
-          newBuffer[cursor] = (newBuffer[cursor] & 0xf0) | value;
-          moveCursorRight();
-        }
-        setBuffer(newBuffer);
-        setIsMSN(!isMSN);
+    if (isHexChar(input)) {
+      const value = parseInt(input, 16);
+			const newBuffer = buffer.slice();
+      if (isMSN) {
+        newBuffer[cursor] = (value << 4) | (newBuffer[cursor] & 0x0f);
+      } else {
+        newBuffer[cursor] = (newBuffer[cursor] & 0xf0) | value;
+        moveCursorRight();
+      }
+			setBuffer(newBuffer);
+      setIsMSN(!isMSN);
+      return;
+    }
+
+    if (input === '?') {
+      return setAppState(AppState.Help);
+    }
+
+    if (input === 'j') {
+      return setAppState(AppState.Jump);
+    }
+
+    if (key.delete || key.backspace) {
+      bufferCommands.delete();
+			setIsMSN(true);
+      return;
+    }
+
+    switch (input) {
+      case CommandChar.InsertByteAtCursor: {
+        bufferCommands.insertAtCursor(new Uint8Array([0]));
+				setIsMSN(true);
         return;
       }
-
-      if (input === '?') {
-        return setAppState(AppState.Help);
-      }
-
-      if (input === 'j') {
-        return setAppState(AppState.Jump);
-      }
-
-      if (key.delete || key.backspace) {
-        bufferCommands.delete();
-        setIsMSN(true);
+      case CommandChar.InsertByteAfterCursor: {
+        bufferCommands.insertAfterCursor(new Uint8Array([0]));
+				setIsMSN(true);
         return;
       }
+    }
 
-      switch (input) {
-        case CommandChar.InsertByteAtCursor: {
-          bufferCommands.insertAtCursor(new Uint8Array([0]));
-          setIsMSN(true);
-          return;
-        }
-        case CommandChar.InsertByteAfterCursor: {
-          bufferCommands.insertAfterCursor(new Uint8Array([0]));
-          setIsMSN(true);
-          return;
-        }
-      }
-
-      if (key.ctrl && input === 's') {
-        return setAppState(AppState.Save);
-      }
-    }, {isActive: enabled});
+    if (key.ctrl && input === 's') {
+      return setAppState(AppState.Save);
+    }
+  }, {isActive: enabled});
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,13 +23,14 @@ const inputFile = path.resolve(process.argv[2]);
 
 const App = () => {
   const {
-    buffer,
-    cursor,
-    offset,
-    cursorCommands,
-    bufferCommands,
-    jumpToOffset
-  } = useBuffer();
+		buffer,
+		cursor,
+		offset,
+		cursorCommands,
+		bufferCommands,
+		jumpToOffset,
+		setBuffer
+	} = useBuffer();
 
   const [errorMsg, setErrorMsg] = useState('');
   const [appState, setAppState] = useState<AppState>(AppState.Edit);
@@ -47,6 +48,7 @@ const App = () => {
 
   useEdit({
     buffer,
+    setBuffer,
     bufferCommands,
     cursor,
     moveCursorRight: cursorCommands.right,
@@ -59,17 +61,17 @@ const App = () => {
       <HexView buffer={buffer} offset={offset} cursor={cursor} />
       <Box flexDirection='column'>
         <Text>{'-'.repeat(SCREEN_W)}</Text>
-          {
-              appState === AppState.Edit
-              ? <StatusInfo buffer={buffer} cursor={cursor} />
-            : appState === AppState.Save
-              ?<SaveDialog buffer={buffer} openFilePath={inputFile} setErrorMsg={setErrorMsg} setAppState={setAppState} />
-            : appState === AppState.Jump
-              ? <JumpDialog jumpToOffsset={jumpToOffset} setAppState={setAppState} />
-            : appState === AppState.Error
-              ? <ErrorDialog error={errorMsg} setAppState={setAppState} />
-            : null
-          }
+        {
+						appState === AppState.Edit
+						? <StatusInfo buffer={buffer} cursor={cursor} />
+        	: appState === AppState.Save
+						?<SaveDialog buffer={buffer} openFilePath={inputFile} setErrorMsg={setErrorMsg} setAppState={setAppState} />
+        	: appState === AppState.Jump
+						? <JumpDialog jumpToOffsset={jumpToOffset} setAppState={setAppState} />
+        	: appState === AppState.Error
+						? <ErrorDialog error={errorMsg} setAppState={setAppState} />
+        	: null
+				}
         <Text>{'-'.repeat(SCREEN_W)}</Text>
       </Box>
     </Box>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ const App = () => {
     cursorCommands,
     bufferCommands,
     jumpToOffset,
-		setBuffer
+    setBuffer
   } = useBuffer();
 
   const [errorMsg, setErrorMsg] = useState('');
@@ -48,7 +48,7 @@ const App = () => {
 
   useEdit({
     buffer,
-		setBuffer,
+    setBuffer,
     bufferCommands,
     cursor,
     moveCursorRight: cursorCommands.right,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,8 +28,7 @@ const App = () => {
     offset,
     cursorCommands,
     bufferCommands,
-    jumpToOffset,
-    setBuffer
+    jumpToOffset
   } = useBuffer();
 
   const [errorMsg, setErrorMsg] = useState('');
@@ -48,7 +47,6 @@ const App = () => {
 
   useEdit({
     buffer,
-    setBuffer,
     bufferCommands,
     cursor,
     moveCursorRight: cursorCommands.right,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,14 +23,14 @@ const inputFile = path.resolve(process.argv[2]);
 
 const App = () => {
   const {
-		buffer,
-		cursor,
-		offset,
-		cursorCommands,
-		bufferCommands,
-		jumpToOffset,
+    buffer,
+    cursor,
+    offset,
+    cursorCommands,
+    bufferCommands,
+    jumpToOffset,
 		setBuffer
-	} = useBuffer();
+  } = useBuffer();
 
   const [errorMsg, setErrorMsg] = useState('');
   const [appState, setAppState] = useState<AppState>(AppState.Edit);
@@ -48,7 +48,7 @@ const App = () => {
 
   useEdit({
     buffer,
-    setBuffer,
+		setBuffer,
     bufferCommands,
     cursor,
     moveCursorRight: cursorCommands.right,
@@ -61,17 +61,17 @@ const App = () => {
       <HexView buffer={buffer} offset={offset} cursor={cursor} />
       <Box flexDirection='column'>
         <Text>{'-'.repeat(SCREEN_W)}</Text>
-        {
-						appState === AppState.Edit
-						? <StatusInfo buffer={buffer} cursor={cursor} />
-        	: appState === AppState.Save
-						?<SaveDialog buffer={buffer} openFilePath={inputFile} setErrorMsg={setErrorMsg} setAppState={setAppState} />
-        	: appState === AppState.Jump
-						? <JumpDialog jumpToOffsset={jumpToOffset} setAppState={setAppState} />
-        	: appState === AppState.Error
-						? <ErrorDialog error={errorMsg} setAppState={setAppState} />
-        	: null
-				}
+          {
+              appState === AppState.Edit
+              ? <StatusInfo buffer={buffer} cursor={cursor} />
+            : appState === AppState.Save
+              ?<SaveDialog buffer={buffer} openFilePath={inputFile} setErrorMsg={setErrorMsg} setAppState={setAppState} />
+            : appState === AppState.Jump
+              ? <JumpDialog jumpToOffsset={jumpToOffset} setAppState={setAppState} />
+            : appState === AppState.Error
+              ? <ErrorDialog error={errorMsg} setAppState={setAppState} />
+            : null
+          }
         <Text>{'-'.repeat(SCREEN_W)}</Text>
       </Box>
     </Box>


### PR DESCRIPTION
`useEdit` hook was mutating the `buffer` variable directly instead of using `useBuffer`. The ui was being updated because of the call to `setIsMSN`, which re-renders the `HexView` component.

I don't know whether or not this actually fixes a bug, but I feel that it - at least - prevents a potential bug from occurring.

P.S. thanks for the video, I learned a lot from you.